### PR TITLE
Fix a small bug in bandwidth_for_scratchpad

### DIFF
--- a/src/loopnest.cpp
+++ b/src/loopnest.cpp
@@ -106,8 +106,8 @@ float Loopnest::bandwidth_for_scratchpad(Array* arr, int datatype_bytes,
   int iters = iters_at_level(lvl);
 
   if(lvl == loops.size()) {
-    total_volume += volume_at_level(*arr,lvl);
-    total_volume*=datatype_bytes;
+    total_volume = volume_at_level(*arr,lvl);
+    total_volume *= datatype_bytes;
   }
 
   float bytes_per_cycle = (float) total_volume / ((float)iters / (float)iters_per_cycle);


### PR DESCRIPTION
I think on line 109 in `loopnest.cpp`, the operator `+=` should be `=`, since we are recomputing the total volume for `lvl == loops.size()`, and should not accumulate the volume from `lvl == loops.size() - 1`, right?